### PR TITLE
Adding explicit reference to image tag in the helm upgrade command

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,7 @@ podTemplate(label: 'test', cloud: 'kubernetes',
                     sh "helm delete --tiller-namespace default hello-world-app-${GIT_BRANCH}"
                 }
                 stage('deploy to prod'){
-                    sh "helm upgrade --install --force --tiller-namespace default --namespace prod --values ./hello-world/chart/values.yaml hello-world-app ./hello-world/chart"
+                    sh "helm upgrade --install --force --tiller-namespace default --namespace prod --values ./hello-world/chart/values.yaml --set tag=${APP_DOCKER_TAG} hello-world-app ./hello-world/chart"
                 }
             }
 


### PR DESCRIPTION
The cicd-demo app's values.yaml references the latest tag but the pipeline tags the resulting image with "${GIT_BRANCH}-${GIT_COMMIT}".

This will explicitly override the image tag from the upgrade command in the pipeline. 